### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Are you using Phi ? You're welcome to star the [GitHub repo](https://github.com/
 [@tobusy / @ARobertDev](https://github.com/ARobertDev) — Discord community member
 </td></tr></table>
 
-[![](https://api.star-history.com/svg?repos=KaKi87/phi-for-vivaldi&type=Timeline&theme=dark)](https://github.com/KaKi87/phi-for-vivaldi)
+[![](https://star-history.dera.page/svg?repos=KaKi87/phi-for-vivaldi&type=Timeline&theme=dark)](https://github.com/KaKi87/phi-for-vivaldi)
 
 ## :link: Related projects
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders. This change points it to a working alternative so the chart displays again. Thank you for maintaining this great theme.